### PR TITLE
Add persisted data plugin, some fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rmmz-electron-template",
   "productName": "Rmmz Electron Template",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A template that will allow you to deploy your Rpg Maker MZ game as an electron app.",
   "main": "./out/main/index.js",
   "author": "DdmDraegonis",
@@ -44,6 +44,7 @@
     "ramda": "^0.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "uuid": "^9.0.1",
     "vite": "^4.4.9",
     "zustand": "^4.4.1"
   }

--- a/src/renderer/public/js/plugins.js
+++ b/src/renderer/public/js/plugins.js
@@ -4,5 +4,6 @@ var $plugins =
 [
 {"name":"CaethyrilAudioPause","status":true,"description":"Pause/resume audio (and Effekseer) with the game loop.","parameters":{"IMPORT_AS_MODULE":"true"}},
 {"name":"EffekseerForRPGMakerMZ_Ex","status":true,"description":"Effekseer Extended plugin v1.70e - 1.05","parameters":{"InstanceMaxCount":"10000","SquareMaxCount":"10000","DistortionEnabled":"true","IMPORT_AS_MODULE":"true"}},
-{"name":"DdmDraegonisSaveOverhaul","status":true,"description":"A plugin to change the Save system to a more modern way.","parameters":{"enable_autosave":"true","maxAutosaves":"5","maxQuicksaves":"5","IMPORT_AS_MODULE":"true"}}
+{"name":"DdmDraegonisSaveOverhaul","status":true,"description":"A plugin to change the Save system to a more modern way.","parameters":{"enable_autosave":"true","maxAutosaves":"5","maxQuicksaves":"5","IMPORT_AS_MODULE":"true"}},
+{"name":"DdmDraegonisPersistedData","status":true,"description":"A plugin to allow persisted data between save files.","parameters":{"variableList":"[\"6\"]","switchList":"[\"6\"]","eventList":"[\"{\\\"mapId\\\":\\\"1\\\",\\\"eventId\\\":\\\"1\\\",\\\"switchId\\\":\\\"A\\\"}\"]","IMPORT_AS_MODULE":"true"}}
 ];

--- a/src/renderer/public/js/plugins/DdmDraegonisPersistedData.js
+++ b/src/renderer/public/js/plugins/DdmDraegonisPersistedData.js
@@ -1,0 +1,98 @@
+/*:
+ * @target MZ
+ * @plugindesc A plugin to allow persisted data between save files.
+ * @author DdmDraegonis
+ * @url https://github.com/Draegonis/rmmz-electron-template
+ * 
+ * @param variableList
+ * @text Variable List
+ * @type variable[]
+ * @default []
+ * 
+ * @param switchList
+ * @text Switch List
+ * @type switch[]
+ * @default []
+ * 
+ * @param eventList
+ * @text Event List
+ * @type struct<SelfSwitch>[]
+ * @default "["{"mapId":"1","eventId":"1","switchId":"A"}"]"
+ * 
+ * @command saveAll
+ * @text Save All Data
+ * @desc Save all registered game variables/switches.
+ *
+ * @command saveVars
+ * @text Save Variables
+ * @desc Save all registered game variables.
+ * 
+ * @command saveSwitches
+ * @text Save Switches
+ * @desc Save all registered game switches.
+ * 
+ * @command saveSelfSwitches
+ * @text Save Self Switches
+ * @desc Save all registered game self switches.
+ * 
+ * 
+ * @command saveSingleVar
+ * @text Save Single Variable
+ * @desc Save a single game variable by given variable id number.
+ * 
+ * @arg varId
+ * @text ID
+ * @type variable
+ * @default 1
+ * @min 1
+ * @desc The id number of the game variable you want to save.
+ * 
+ * @command saveSingleSwitch
+ * @text Save Single Switch
+ * @desc Save a single game switch by given variable id number.
+ * 
+ * @arg switchId
+ * @text ID
+ * @type switch
+ * @default 1
+ * @min 1
+ * @desc The id number of the game switch you want to save.
+ * 
+ * @command saveSingleSelfSwitch
+ * @text Save Single Self Switch
+ * @desc Save a single game switch by given variable id number.
+ * 
+ * @arg selfSW_id
+ * @text ID
+ * @type struct<SelfSwitch>
+ * @default "{"mapId":"1","eventId":"1","switchId":"A"}"
+ * 
+ * @param IMPORT_AS_MODULE
+ * @text Import as Module
+ * @type boolean
+ * @default true
+ * 
+ * @help 
+ * 
+ * You can use this plugin to persist certain game variables switches or self switches
+ * in order to make achievements or a rouge like game.
+ * 
+ * Released under the MIT License.
+ */
+/*~struct~SelfSwitch:
+ * @param mapId
+ * @type number
+ * @default 1
+ * @min 1
+ * 
+ * @param eventId
+ * @type number
+ * @default 1
+ * @min 1
+ * 
+ * @param switchId
+ * @type string
+ * @default A
+ */
+
+await window.loadPluginJs('DdmDraegonisPersistedData')

--- a/src/renderer/public/js/plugins/DdmDraegonisSaveOverhaul.js
+++ b/src/renderer/public/js/plugins/DdmDraegonisSaveOverhaul.js
@@ -34,7 +34,7 @@
  * It allows for a set number of autosaves that will be cycled through when it saves. Those autosaves
  * can't be overwriten when manually saving.
  * 
- * Free to use and/or modify for any project. No credit required.
+ * Released under the MIT License.
  */
 
 await window.loadPluginJs('DdmDraegonisSaveOverhaul')

--- a/src/renderer/src/helpers/gameFuncs.js
+++ b/src/renderer/src/helpers/gameFuncs.js
@@ -1,0 +1,203 @@
+/**
+ * Similar to a foreach loop with a callback on each iteration.
+ * @param {number} first the first number in the for loop.
+ * @param {number} last the last number in the for loop
+ * @param {function} callback the callback to be used on each number from
+ * the first to the last.
+ */
+const forEachRange = function (first, last, callback) {
+  for (let num = first; num <= last; num++) {
+    callback(num)
+  }
+}
+/**
+ * @description A function used to verify if the id number
+ * for $gameVariables is valid and is initialized.
+ * @param {number} id The id number of the game variable.
+ * @returns {boolean} Returns true if passed verification.
+ */
+export const verifyGameVariable = function (id) {
+  return (
+    window.$gameSwitches && window.$dataSystem && id > 0 && id < window.$dataSystem.variables.length
+  )
+}
+/**
+ * @description A function used to verify if the id number
+ * for $gameSwitches is valid and is initialized.
+ * @param {number} id The id number of the game switch.
+ * @returns {boolean} Returns true if passed verification.
+ */
+export const verifyGameSwitch = function (id) {
+  return (
+    window.$gameSwitches && window.$dataSystem && id > 0 && id < window.$dataSystem.switches.length
+  )
+}
+/**
+ * @description Method that wraps the $gameSelfSwitches.setValue but called
+ * for a range of event id of the map.
+ * @param {[number, number]} range - first number, last number of the range.
+ * @param {[number, string]} key - an array containing mapId, and switchId.
+ * Ex: [4, 'B']. The eventIds are supplied by the range.
+ * @param {boolean} newValue - the new boolean value of all the self switches.
+ */
+export const setSelfSwitchByRange = function (key, range, newValue) {
+  const [mapId, switchId] = key
+  forEachRange(...range, function (num) {
+    setSelfSwitch(mapId, num, switchId, newValue)
+  })
+}
+/**
+ * @description Method that wraps the $gameSwitches.setValue for a range
+ * ids to the same new value.
+ * @param {[number, number]} range - first number, last number of the range.
+ * @param {boolean} newValue - the new boolean value for all the switches.
+ */
+export const setSwitchesByRange = function (range, newValue) {
+  forEachRange(...range, function (num) {
+    setSwitch(num, newValue)
+  })
+}
+/**
+ * @description Method that wraps the $gameVariables.setValue for a range
+ * ids to the same new value.
+ * @param {[number, number]} range - first number, last number of the range.
+ * @param {any} newValue - the new value to set to all the ids.
+ */
+export const setVariablesByRange = function (range, newValue) {
+  forEachRange(...range, function (num) {
+    setVariable(num, newValue)
+  })
+}
+/**
+ * @description A function wrapper for $gameSwitches.setValue.
+ * @param {number} switchId - the switch id to set the value to.
+ * @param {boolean} newValue - the new value for the switch.
+ */
+export const setSwitch = function (switchId, newValue) {
+  if (verifyGameSwitch(switchId)) {
+    window.$gameSwitches.setValue(switchId, newValue)
+  }
+}
+/**
+ * @description A function wrapper for $gameVariables.setValue.
+ * @param {number} variableId - the switch id to set the value to.
+ * @param {any} newValue - the new value for the switch.
+ */
+export const setVariable = function (variableId, newValue) {
+  if (verifyGameVariable(variableId)) {
+    window.$gameVariables.setValue(variableId, newValue)
+  }
+}
+/**
+ * A function wrapper on $gameSelfSwitches.
+ * @param {[number, number, string]} key - an array containing mapId, eventId, and switchId.
+ * Ex: [40, 35, 'A']
+ * @param {boolean} newValue - the new boolean value of the switch.
+ */
+export const setSelfSwitch = function (key, newValue) {
+  if (window.$gameSelfSwitches) window.$gameSelfSwitches.setValue(key, newValue)
+}
+/**
+ * @description Method that wraps the $gameSelfSwitches.value but called
+ * for a range of event ids of the map.
+ * @param {[number, number]} range - first number, last number of the range.
+ * @param {[number, string]} key - an array containing mapId, and switchId.
+ * Ex: [77, 'C']. The eventIds are supplied by the range.
+ * @returns {{ [number]: any | null }} a dictionary of eventId: switchId values.
+ */
+export const getSelfSwitchByRange = function (key, range) {
+  const [mapId, switchId] = key
+  const collector = {}
+  forEachRange(...range, function (num) {
+    getSelfSwitch(`${mapId}, ${num}, ${switchId.toUpperCase()}`)
+  })
+  return collector
+}
+/**
+ * @description Method that wraps the $gameSwitches.value for a range
+ * ids.
+ * @param {[number, number]} range - first number, last number of the range.
+ * @return { { [number]: boolean | null } } A dictionary of switchId: boolean or null
+ * if not found.
+ */
+export const getSwitchesByRange = function (range) {
+  const collector = {}
+  forEachRange(...range, function (num) {
+    collector[num] = getSwitch(num)
+  })
+  return collector
+}
+/**
+ * @description Method that wraps the $gameSwitches.value for a range
+ * ids.
+ * @param {[number, number]} range - first number, last number of the range.
+ * @return { { [number]: any | any[] | null } } A dictionary of variableId: any value,
+ * null if not found.
+ */
+export const getVariablesByRange = function (range) {
+  const collector = {}
+  forEachRange(...range, function (num) {
+    collector[num] = getVariable(num)
+  })
+  return collector
+}
+/**
+ * A function wrapper on $gameSwitches.value.
+ * @param {number} switchId - the switch id number to get the value of.
+ * @returns {boolean | null} - a boolean or null if the value is not found.
+ */
+export const getSwitch = function (switchId) {
+  let switchBoolean = null
+  if (verifyGameSwitch(switchId)) {
+    switchBoolean = window.$gameSwitches.value(switchId)
+  }
+  return switchBoolean
+}
+/**
+ * A function wrapper on $gameVariable.value.
+ * @param {number} variableId - the id number of the variable to get
+ * @returns {any | any[] | null} - the value of the gameVariable or null if not found.
+ */
+export const getVariable = function (variableId) {
+  let variableValue = null
+  if (verifyGameVariable(variableId)) {
+    variableValue = window.$gameVariables.value(variableId)
+  }
+  return variableValue
+}
+/**
+ * A function wrapper on $gameSelfSwitches.value.
+ * @param {[number, number, string]} key - an array containing mapId, eventId, and switchId.
+ * Ex: [44, 33, 'D']
+ * @returns {any | null} the value of the selfSwitch or null if not found.
+ */
+export const getSelfSwitch = function (key) {
+  let selfSwitch = null
+  if (window.$gameSelfSwitches) {
+    selfSwitch = window.$gameSelfSwitches.value(key)
+  }
+  return selfSwitch
+}
+
+// Collect all the same types of functions into a dictionary for variable access.
+// Ex: setGameVars[varType]
+export const setGameVars = {
+  var: setVariable,
+  switch: setSwitch,
+  selfSW: setSelfSwitch
+}
+export const setGameVarsByRamge = {
+  var: setVariablesByRange,
+  switch: setSwitchesByRange,
+  selfSW: setSelfSwitchByRange
+}
+export const getGameVars = {
+  var: getVariable,
+  switch: getSwitch,
+  selfSW: getSelfSwitch
+}
+export const getGameVarsByRange = {
+  var: getVariablesByRange,
+  switch: getSwitchesByRange,
+  selfSW: getSelfSwitchByRange
+}

--- a/src/renderer/src/helpers/gameParsers.js
+++ b/src/renderer/src/helpers/gameParsers.js
@@ -1,0 +1,6 @@
+export const parseSelfSW = (id) => {
+  const newId = JSON.parse(id)
+  return [Number(newId.mapId || -1), Number(newId.eventId || -1), newId.switchId.toUpperCase()]
+}
+
+export const parseNumber = (value) => Number(value || -1)

--- a/src/renderer/src/managers/coreManager.js
+++ b/src/renderer/src/managers/coreManager.js
@@ -1,0 +1,21 @@
+class Ddm_CoreManager {
+  gameSavePath(saveName) {
+    return ['save', saveName + '.rmmzsave']
+  }
+
+  async fileExists(folder, file) {
+    return await window.electron.ipcRenderer.invoke('file-exists', folder, file)
+  }
+
+  async saveToFile(folder, file, data, compress) {
+    return await window.electron.ipcRenderer.invoke('save-object', folder, file, data, compress)
+  }
+
+  async loadFromFile(folder, file, deCompress) {
+    return await window.electron.ipcRenderer.invoke('read-object', folder, file, deCompress)
+  }
+}
+
+const CoreManager = new Ddm_CoreManager()
+
+export { CoreManager }

--- a/src/renderer/src/plugins/DdmDraegonisPersistedData.js
+++ b/src/renderer/src/plugins/DdmDraegonisPersistedData.js
@@ -1,0 +1,340 @@
+// Store
+import { create } from 'zustand'
+import { persist, devtools } from 'zustand/middleware'
+import { immer } from 'zustand/middleware/immer'
+// Managers
+import { CoreManager } from '../managers/coreManager'
+// Data
+import { v4 as uuidV4 } from 'uuid'
+// Helpers
+import { setGameVars, getGameVars } from '../helpers/gameFuncs'
+import { parseSelfSW, parseNumber } from '../helpers/gameParsers'
+import { isEmpty as r_isEmpty } from 'ramda'
+
+// ==============================================================
+// PLUGIN SETUP
+
+const pluginName = 'DdmDraegonisPersistedData'
+
+window.Imported = window.Imported || {}
+window.Imported[pluginName] = 1.0
+
+const params = window.PluginManager.parameters(pluginName)
+
+// ==============================================================
+// STORE SETUP
+
+const persistPath = ['save', 'persistData.rmmzsave']
+
+// ===================================================
+//                    INIT-STATE
+
+/**
+ * The initial state for the persist store.
+ */
+const initPersist = {
+  isInit: false,
+  currentId: '',
+  stored: {
+    var: {},
+    switch: {},
+    selfSW: {}
+  }
+}
+
+/**
+ * A function that updates specific parts of state.stored in the database.
+ * @param {string} key - the key in state.stored to update.
+ * @param {Draft["stored"]} stored - the WritableDraft of state.stored.
+ */
+const storeSingleType = (key, state) => {
+  const stored = state.stored
+  const setVarsToStore = () => {
+    if (stored && !r_isEmpty(stored.var)) {
+      for (const id of Object.keys(stored.var)) {
+        const newValue = getGameVars.var(id)
+        stored.var[id] = newValue
+      }
+    }
+  }
+  const setSwitchesToStore = () => {
+    if (stored && !r_isEmpty(stored.switch)) {
+      for (const id of Object.keys(stored.switch)) {
+        const newValue = getGameVars.switch(id)
+        stored.switch[id] = newValue
+      }
+    }
+  }
+  const setSelfSWtoStore = () => {
+    if (stored && !r_isEmpty(stored.selfSW)) {
+      for (const id of Object.keys(stored.selfSW)) {
+        const newValue = getGameVars.selfSW(id)
+        stored.selfSW[id] = newValue
+      }
+    }
+  }
+  // Settingg the variable/switch/selfSW data to the store.
+
+  switch (key) {
+    case 'var':
+      setVarsToStore()
+      break
+    case 'switch':
+      setSwitchesToStore()
+      break
+    case 'selfSW':
+      setSelfSWtoStore()
+      break
+    case 'all':
+      setVarsToStore()
+      setSwitchesToStore()
+      setSelfSWtoStore()
+      break
+  }
+}
+
+/**
+ * A function that sets a new uuid string to the store,
+ * in the rare case the new id is the same it will generate a new one.
+ * @param {Draft} state - the WritableDraft to compare the uuid string.
+ * @returns {string} returns the new uuid string.
+ */
+const setNewId = (state) => {
+  let newId = ''
+
+  do {
+    newId = uuidV4()
+  } while (newId === state.currentId)
+
+  state.currentId = newId
+
+  return newId
+}
+
+// ===================================================
+//                     STORE
+
+/**
+ * The Zustand store that manages the persist state. It uses indexeddb so the data
+ * can be retrieved for all save games.
+ */
+const persistStore = create(
+  devtools(
+    persist(
+      immer((set, get) => ({
+        ...initPersist,
+        /**
+         * A function to initialize the store variables with the data in DdmPersist.json.
+         */
+        initStore() {
+          const isInit = get().isInit
+
+          if (isInit) return
+
+          // params here for starting state.
+          const variableList = JSON.parse(params.variableList)
+          const switchList = JSON.parse(params.switchList)
+          const eventList = JSON.parse(params.eventList)
+
+          let convertedEventList = undefined
+          if (eventList.length > 0) {
+            convertedEventList = eventList.map(parseSelfSW)
+          }
+
+          const StoreIndex = {
+            var: variableList.length > 0 ? variableList.map(parseNumber) : undefined,
+            switch: switchList.length > 0 ? switchList.map(parseNumber) : undefined,
+            selfSW: convertedEventList ? convertedEventList : undefined
+          }
+
+          set((state) => {
+            state.currentId = uuidV4()
+
+            Object.keys(StoreIndex).forEach((key) => {
+              if (StoreIndex[key]) {
+                StoreIndex[key].forEach((entry) => {
+                  state.stored[key][entry] = null
+                })
+              }
+            })
+
+            state.isInit = true
+          })
+        },
+        /**
+         * Fetches the data in the store if needed. If the uuid Id is the same it shouldn't
+         * need to fetch since the data should be the same as the data in the store.
+         * @param {string} storeId - the uuid stored in the save file to be compared with
+         * the uuid in the store.
+         */
+        loadStore(storeId) {
+          const { currentId, stored } = get()
+
+          if (currentId !== storeId && stored) {
+            Object.entries(stored).forEach(([key, obj]) => {
+              if (!r_isEmpty(stored[key])) {
+                Object.entries(obj).forEach(([id, value]) => {
+                  if (value !== null) setGameVars[key](id, value)
+                })
+              }
+            })
+          }
+        },
+        /**
+         * Updates the data in the localStorage.
+         * @returns {string} Returns a uuid string to be saved into the Rmmz save file.
+         */
+        saveStore() {
+          let newId = ''
+
+          set((state) => {
+            newId = setNewId(state)
+            storeSingleType('all', state)
+          })
+
+          return newId
+        },
+        saveSingleValue(type, id) {
+          set((state) => {
+            const stored = state.stored[type]
+
+            const newValue = getGameVars[type](id)
+            if (newValue !== null) {
+              stored[id] = newValue
+              setNewId(state)
+            }
+          })
+        },
+        saveSingleType(keyToUpdate) {
+          set((state) => {
+            storeSingleType(keyToUpdate, state)
+            setNewId(state)
+          })
+        }
+      })),
+      {
+        name: `${pluginName}`,
+        /**
+         * To set/get/remove from indexeddb and able to handle the
+         * stored object maps.
+         */
+        storage: {
+          getItem: async () => {
+            const storeState = await CoreManager.loadFromFile(...persistPath, true)
+
+            return {
+              state: {
+                ...storeState
+              }
+            }
+          },
+          setItem: async (_, newValue) => {
+            const storeData = newValue.state
+
+            // this is to remove all functions
+            const str = JSON.stringify(storeData)
+            const toSave = JSON.parse(str)
+
+            await CoreManager.saveToFile(...persistPath, toSave, true)
+          }
+        }
+      }
+    ),
+    {
+      name: `${pluginName}`,
+      serialize: {
+        options: {
+          map: true
+        }
+      }
+    }
+  )
+)
+
+// ===================================================
+//                      MANAGER
+
+/**
+ * The static manager class to expose the functions onto the api.
+ */
+class PersistManager {
+  #initStore = persistStore.getState().initStore
+  #loadStore = persistStore.getState().loadStore
+  #saveStore = persistStore.getState().saveStore
+  #saveSingleValue = persistStore.getState().saveSingleValue
+  #saveSingleType = persistStore.getState().saveSingleType
+
+  async onStart(refresh) {
+    this.#initStore(refresh)
+  }
+
+  onLoad(persistUUID) {
+    this.#loadStore(persistUUID)
+  }
+
+  onSave() {
+    return this.#saveStore()
+  }
+
+  saveSingleValue(updateType, updateId) {
+    this.#saveSingleValue(updateType, updateId)
+  }
+
+  saveSingleType(updateKey) {
+    this.#saveSingleType(updateKey)
+  }
+}
+
+const PersistDataManager = new PersistManager()
+
+PersistDataManager.onStart()
+
+// ============================================================================
+// PLUGIN COMMANDS
+
+// These are provided if you want to save outside of the normal saving.
+window.PluginManager.registerCommand(pluginName, 'saveAll', () => {
+  PersistDataManager.onSave()
+})
+window.PluginManager.registerCommand(pluginName, 'saveVars', () => {
+  PersistDataManager.saveSingleType('var')
+})
+window.PluginManager.registerCommand(pluginName, 'saveSwitches', () => {
+  PersistDataManager.saveSingleType('switch')
+})
+window.PluginManager.registerCommand(pluginName, 'saveSelfSwitches', () => {
+  PersistDataManager.saveSingleType('selfSW')
+})
+
+// These can be used to add a new value to be persisted later on in a game.
+window.PluginManager.registerCommand(pluginName, 'saveSingleVar', ({ varId }) => {
+  PersistDataManager.saveSingleValue('var', parseNumber(varId))
+})
+window.PluginManager.registerCommand(pluginName, 'saveSingleSwitch', ({ switchId }) => {
+  PersistDataManager.saveSingleValue('switch', parseNumber(switchId))
+})
+window.PluginManager.registerCommand(pluginName, 'saveSingleSelfSwitch', ({ selfSW_id }) => {
+  PersistDataManager.saveSingleValue('selfSW', parseSelfSW(selfSW_id))
+})
+
+// ==================================================================
+// PLUGIN ALIAS
+
+const DDM_ALIAS_DATAMANGER_SETUPNEWGAME = window.DataManager.setupNewGame
+window.DataManager.setupNewGame = function () {
+  DDM_ALIAS_DATAMANGER_SETUPNEWGAME.call(this)
+  PersistDataManager.onLoad('')
+}
+
+const DDM_ALIAS_DATAMANAGER_MAKESAVECONTENTS = window.DataManager.makeSaveContents
+window.DataManager.makeSaveContents = function () {
+  const contents = DDM_ALIAS_DATAMANAGER_MAKESAVECONTENTS.call(this)
+  contents.persistUUID = PersistDataManager.onSave()
+  return contents
+}
+
+const DDM_ALIAS_DATAMANAGER_EXTRACTSAVECONTENTS = window.DataManager.extractSaveContents
+window.DataManager.extractSaveContents = function (contents) {
+  DDM_ALIAS_DATAMANAGER_EXTRACTSAVECONTENTS.call(this, contents)
+  PersistDataManager.onLoad(contents.persistUUID)
+}

--- a/src/renderer/src/plugins/DdmDraegonisSaveOverhaul.js
+++ b/src/renderer/src/plugins/DdmDraegonisSaveOverhaul.js
@@ -1,3 +1,4 @@
+import { CoreManager } from '../managers/coreManager'
 import { addNewInput } from '../store/inputs/useInputStore'
 
 // ================================================
@@ -102,11 +103,8 @@ window.DataManager.removeInvalidGlobalInfo = async function () {
     // savefileId is the same as the saveFileName
     const savefileId = info.savefileId
     // Changed logic to make sure it runs in order.
-    const isSave = await window.electron.ipcRenderer.invoke(
-      'file-exists',
-      'save',
-      `${savefileId}.rmmzsave`
-    )
+    const isSave = await CoreManager.fileExists(...CoreManager.gameSavePath(savefileId))
+
     const infoIndex = this._globalInfo.findIndex((file) => file.savefileId === savefileId)
 
     if (!isSave) {
@@ -137,10 +135,6 @@ window.DataManager.removeInvalidGlobalInfo = async function () {
     // save the new global info.
     window.DataManager.saveGlobalInfo()
   }
-}
-
-window.DataManager.isAnySavefileExists = function () {
-  return this._globalInfo.some((x) => x)
 }
 
 // lastest save is always index 0 savefileId.
@@ -433,10 +427,6 @@ delete window.Scene_File.prototype.needsAutosave
 // ================================================
 // Scene_Save
 
-window.Scene_Save.prototype.helpWindowText = function () {
-  return window.TextManager.saveMessage
-}
-
 window.Scene_Save.prototype.firstSavefileId = function () {
   return 0
 }
@@ -540,20 +530,9 @@ window.Scene_Map.prototype.quickload = function () {
 // Add to updateScene in Scene_Map + add functions
 // to get the quickload and quicksave working.
 
+const DDM_ALIAS_SCENE_MAP_UPDATESCENE = window.Scene_Map.prototype.updateScene
 window.Scene_Map.prototype.updateScene = function () {
-  this.checkGameover()
-  if (!window.SceneManager.isSceneChanging()) {
-    this.updateTransferPlayer()
-  }
-  if (!window.SceneManager.isSceneChanging()) {
-    this.updateEncounter()
-  }
-  if (!window.SceneManager.isSceneChanging()) {
-    this.updateCallMenu()
-  }
-  if (!window.SceneManager.isSceneChanging()) {
-    this.updateCallDebug()
-  }
+  DDM_ALIAS_SCENE_MAP_UPDATESCENE.call(this)
   if (!window.SceneManager.isSceneChanging()) {
     this.updateQuicksave()
   }

--- a/src/renderer/src/rmmz/edits/managers/dataManager.js
+++ b/src/renderer/src/rmmz/edits/managers/dataManager.js
@@ -1,4 +1,6 @@
 import { DataManager, BattleManager } from '../../rmmz_managers'
+// Custom
+import { CoreManager } from '../../../managers/coreManager'
 
 // EDIT: globalInfo returned from electron can be false, since it is not rejected on electron side.
 DataManager.loadGlobalInfo = function () {
@@ -44,8 +46,12 @@ DataManager.removeInvalidGlobalInfo = function () {
   for (const info of globalInfo) {
     const savefileId = globalInfo.indexOf(info)
     const saveFileName = this.makeSavename(savefileId)
-    window.electron.ipcRenderer
-      .invoke('file-exists', 'save', StorageManager.fileName(saveFileName))
+    CoreManager.fileExists(...StorageManager.filePath(saveFileName))
+      .then((resp) => {
+        if (!resp) {
+          delete globalInfo[savefileId]
+        }
+      })
       .catch(() => {
         delete globalInfo[savefileId]
       })

--- a/src/renderer/src/rmmz/edits/managers/storageManager.js
+++ b/src/renderer/src/rmmz/edits/managers/storageManager.js
@@ -1,23 +1,18 @@
 import { StorageManager } from '../../rmmz_managers'
+import { CoreManager } from '../../../managers/coreManager'
 
 // EDIT: StorageManager is mostly done on the electron side, only really need
 // saveObject, loadObject and filepath.
 StorageManager.saveObject = function (saveName, object) {
-  return window.electron.ipcRenderer.invoke(
-    'save-object',
-    'save',
-    this.fileName(saveName),
-    object,
-    true
-  )
+  return CoreManager.saveToFile(...this.filePath(saveName), object, true)
 }
 
 StorageManager.loadObject = function (saveName) {
-  return window.electron.ipcRenderer.invoke('read-object', 'save', this.fileName(saveName), true)
+  return CoreManager.loadFromFile(...this.filePath(saveName), true)
 }
 
-StorageManager.fileName = function (saveName) {
-  return saveName + '.rmmzsave'
+StorageManager.filePath = function (saveName) {
+  return CoreManager.gameSavePath(saveName)
 }
 
 export { StorageManager }

--- a/src/renderer/src/store/inputs/useInputStore.js
+++ b/src/renderer/src/store/inputs/useInputStore.js
@@ -2,13 +2,15 @@ import { isEmpty as r_isEmpty } from 'ramda'
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
+// Managers
+import { CoreManager } from '../../managers/coreManager'
+
+const filePath = ['', 'inputIndex.json']
 
 const saveInputToFile = async (commandIndexData) => {
-  await window.electron.ipcRenderer
-    .invoke('save-object', undefined, 'inputIndex.json', commandIndexData, false)
-    .catch(() => {
-      console.log('Default Command Index failed to save.')
-    })
+  await CoreManager.saveToFile(...filePath, commandIndexData, false).catch(() => {
+    console.log('Default Command Index failed to save.')
+  })
 }
 
 const defaultCommandIndex = {
@@ -72,19 +74,10 @@ Object.entries(defaultCommandIndex).forEach(([command, inputObj]) => {
 let commandIndexData = undefined
 let inputIndexData = undefined
 
-const fileExists = await window.electron.ipcRenderer.invoke(
-  'file-exists',
-  undefined,
-  'inputIndex.json'
-)
+const fileExists = await CoreManager.fileExists(...filePath)
 
 if (fileExists) {
-  const commandInputData = await window.electron.ipcRenderer.invoke(
-    'read-object',
-    undefined,
-    'inputIndex.json',
-    false
-  )
+  const commandInputData = await CoreManager.loadFromFile(...filePath, false)
 
   // Set new input index data.
   inputIndexData = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4303,6 +4303,11 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 verror@^1.10.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz#4bf09eeccf4563b109ed4b3d458380c972b0cdeb"


### PR DESCRIPTION
Add a plugin that allows persisted data between save files for game variables, switches and self switches.

Added uuid package to the package.json.

Started a manager to hold core functionality.
Updated save related functions to use the CoreManager.

Some minor changes to SaveOverhaul: 
- added onQuicksaveSuccess
- put a check to see if the player needs to request a map reload
- remove window.DataManager.isAnySavefileExists and window.Scene_Save.prototype.helpWindowText
- Changed quicksave to use DataManager.saveGame

