### PR TITLE
add location fixes and fix bug in window resolution change

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -178,6 +178,13 @@ ipcMain.handle('load-config', () => {
 })
 
 ipcMain.on('save-config', (_, config) => {
+  // Set the settings variable here to minWidth/minHeight.
+  settings.width = config.window.minWidth
+  settings.minWidth = config.window.minWidth
+  settings.height = config.window.minHeight
+  settings.minHeight = config.window.minHeight
+  // Set the ratio as well.
+  settings.ratio = config.window.ratio
   store.set('settings', config)
 })
 

--- a/src/renderer/src/rmmz/edits/editsIndex.js
+++ b/src/renderer/src/rmmz/edits/editsIndex.js
@@ -40,7 +40,8 @@ import { Window_GameEnd } from './window/gameEnd'
 import { Window_MenuCommand } from './window/menuCommand'
 import { Window_Options } from './window/options'
 import { Window_TitleCommand } from './window/titleCommand'
-
+// Sprite edits
+import { Sprite_Enemy } from './sprite/enemy'
 // Re-export all edits
 export {
   // CORE EDITED
@@ -84,5 +85,7 @@ export {
   Window_GameEnd,
   Window_MenuCommand,
   Window_Options,
-  Window_TitleCommand
+  Window_TitleCommand,
+  // SPRITES EDITED
+  Sprite_Enemy
 }

--- a/src/renderer/src/rmmz/edits/editsIndex.js
+++ b/src/renderer/src/rmmz/edits/editsIndex.js
@@ -43,6 +43,7 @@ import { Window_TitleCommand } from './window/titleCommand'
 // Sprite edits
 import { Sprite_Enemy } from './sprite/enemy'
 import { Sprite_Battleback } from './sprite/battleback'
+import { Sprite_Actor } from './sprite/actor'
 // Re-export all edits
 export {
   // CORE EDITED
@@ -89,5 +90,6 @@ export {
   Window_TitleCommand,
   // SPRITES EDITED
   Sprite_Enemy,
-  Sprite_Battleback
+  Sprite_Battleback,
+  Sprite_Actor
 }

--- a/src/renderer/src/rmmz/edits/editsIndex.js
+++ b/src/renderer/src/rmmz/edits/editsIndex.js
@@ -42,6 +42,7 @@ import { Window_Options } from './window/options'
 import { Window_TitleCommand } from './window/titleCommand'
 // Sprite edits
 import { Sprite_Enemy } from './sprite/enemy'
+import { Sprite_Battleback } from './sprite/battleback'
 // Re-export all edits
 export {
   // CORE EDITED
@@ -87,5 +88,6 @@ export {
   Window_Options,
   Window_TitleCommand,
   // SPRITES EDITED
-  Sprite_Enemy
+  Sprite_Enemy,
+  Sprite_Battleback
 }

--- a/src/renderer/src/rmmz/edits/managers/configManager.js
+++ b/src/renderer/src/rmmz/edits/managers/configManager.js
@@ -51,11 +51,11 @@ ConfigManager.applyData = function (config) {
 // Edit: Add function to convert sizes to ratios.
 ConfigManager.getScreenRatio = function (width, height) {
   switch ((width, height)) {
-    case (1280, 1024):
+    case (1000, 800):
       return 1.25
     case (1024, 768):
       return 1.33
-    case (1280, 720):
+    case (1024, 576):
       return 1.78
     case (1280, 540):
       return 2.37
@@ -68,11 +68,11 @@ ConfigManager.getScreenRatio = function (width, height) {
 ConfigManager.getSizeByRatio = function (ratio) {
   switch (ratio) {
     case 1.25:
-      return [1280, 1024]
+      return [1000, 800]
     case 1.33:
       return [1024, 768]
     case 1.78:
-      return [1280, 720]
+      return [1024, 576]
     case 2.37:
       return [1280, 540]
     default:

--- a/src/renderer/src/rmmz/edits/scenes/base.js
+++ b/src/renderer/src/rmmz/edits/scenes/base.js
@@ -1,6 +1,6 @@
 import { Scene_Base } from '../../rmmz_scenes'
 // Edited
-import { DataManager } from '../editsIndex'
+import { ConfigManager, DataManager } from '../editsIndex'
 
 Scene_Base.prototype.executeAutosave = function () {
   window.$gameSystem.onBeforeSave()
@@ -13,6 +13,15 @@ Scene_Base.prototype.executeAutosave = function () {
       }
     })
     .catch(() => this.onAutosaveFailure())
+}
+
+// EDIT: Adjust UI to the config manager size and not size defined by the editor.
+Scene_Base.prototype.adjustBoxSize = function () {
+  const uiAreaWidth = ConfigManager.window.minWidth
+  const uiAreaHeight = ConfigManager.window.minHeight
+  const boxMargin = 4
+  window.Graphics.boxWidth = uiAreaWidth - boxMargin * 2
+  window.Graphics.boxHeight = uiAreaHeight - boxMargin * 2
 }
 
 export { Scene_Base }

--- a/src/renderer/src/rmmz/edits/sprite/actor.js
+++ b/src/renderer/src/rmmz/edits/sprite/actor.js
@@ -1,0 +1,38 @@
+import { Sprite_Actor } from '../../rmmz_sprites'
+// Import edited
+import { ConfigManager } from '../editsIndex'
+
+// EDIT: new function to calculate the adjusted and offset positions.
+const adjustPosition = (index) => {
+  const currentWidth = ConfigManager.window.minWidth
+  const currentHeight = ConfigManager.window.minHeight
+  const ratio = ConfigManager.window.ratio
+
+  switch (ratio) {
+    case 1.25: {
+      return [currentWidth - 125, currentHeight - 500, 0, index * 100]
+    }
+    case 1.33: {
+      return [currentWidth - 150, currentHeight - 425, 0, index * 75]
+    }
+    case 1.78: {
+      return [currentWidth - 175, currentHeight - 340, index * 32, index * 48]
+    }
+    case 2.37: {
+      return [currentWidth - 200, currentHeight - 350, index * 32, index * 48]
+    }
+    default: {
+      throw new Error(`Cannot set home position of actors with a ratio of ${ratio} in actors.js.`)
+    }
+  }
+}
+
+// EDIT: adjust x and y by factoring in minWidth and minHeight.
+// You may need to change the values based on your game.
+Sprite_Actor.prototype.setActorHome = function (index) {
+  const [adjustedX, adjustedY, offsetX, offsetY] = adjustPosition(index)
+  console.log(adjustedX, adjustedY, offsetX, offsetY)
+  this.setHome(adjustedX + offsetX, adjustedY + offsetY)
+}
+
+export { Sprite_Actor }

--- a/src/renderer/src/rmmz/edits/sprite/battleback.js
+++ b/src/renderer/src/rmmz/edits/sprite/battleback.js
@@ -1,0 +1,21 @@
+import { Sprite_Battleback } from '../../rmmz_sprites'
+// Import edited
+import { Graphics, ConfigManager } from '../editsIndex'
+
+Sprite_Battleback.prototype.adjustPosition = function () {
+  this.width = Math.floor((1000 * Graphics.width) / 816)
+  this.height = Math.floor((740 * Graphics.height) / 624)
+  this.x = (Graphics.width - this.width) / 2
+  if (window.$gameSystem.isSideView()) {
+    this.y = Graphics.height - this.height
+  } else {
+    this.y = 0
+  }
+  const ratioX = this.width / this.bitmap.width
+  const ratioY = this.height / this.bitmap.height
+  const scale = Math.max(ratioX, ratioY, 1.0)
+  this.scale.x = scale
+  this.scale.y = ConfigManager.window.ratio === 2.37 ? 1 : scale
+}
+
+export { Sprite_Battleback }

--- a/src/renderer/src/rmmz/edits/sprite/enemy.js
+++ b/src/renderer/src/rmmz/edits/sprite/enemy.js
@@ -1,0 +1,20 @@
+import { Sprite_Battler, Sprite_Enemy } from '../../rmmz_sprites'
+// Import Edited
+import { ConfigManager } from '../editsIndex'
+
+// EDIT: Adjust the home position of enemies based on the difference
+// from the editor and the actual.
+Sprite_Enemy.prototype.setBattler = function (battler) {
+  Sprite_Battler.prototype.setBattler.call(this, battler)
+  this._enemy = battler
+  const battleAreaWidth = ConfigManager.window.minWidth
+  const battleAreaHeight = ConfigManager.window.minHeight
+  const baseWidth = window.$dataSystem.advanced.screenWidth
+  const baseHeight = window.$dataSystem.advanced.screenHeight
+  const adjustedX = (battleAreaWidth / baseWidth) * battler.screenX()
+  const adjustedY = (battleAreaHeight / baseHeight) * battler.screenY()
+  this.setHome(adjustedX, adjustedY)
+  this._stateIconSprite.setup(battler)
+}
+
+export { Sprite_Enemy }

--- a/src/renderer/src/rmmz/index.js
+++ b/src/renderer/src/rmmz/index.js
@@ -60,7 +60,6 @@ import {
   Scene_Status
 } from './rmmz_scenes'
 import {
-  Sprite_Actor,
   Sprite_Animation,
   Sprite_AnimationMV,
   Sprite_Balloon,
@@ -177,7 +176,8 @@ import {
   Window_GameEnd,
   // Sprites
   Sprite_Enemy,
-  Sprite_Battleback
+  Sprite_Battleback,
+  Sprite_Actor
 } from './edits/editsIndex'
 //=========================================
 // Import Custom

--- a/src/renderer/src/rmmz/index.js
+++ b/src/renderer/src/rmmz/index.js
@@ -64,7 +64,6 @@ import {
   Sprite_Animation,
   Sprite_AnimationMV,
   Sprite_Balloon,
-  Sprite_Battleback,
   Sprite_Battler,
   Sprite_Button,
   Sprite_Character,
@@ -177,7 +176,8 @@ import {
   Window_TitleCommand,
   Window_GameEnd,
   // Sprites
-  Sprite_Enemy
+  Sprite_Enemy,
+  Sprite_Battleback
 } from './edits/editsIndex'
 //=========================================
 // Import Custom

--- a/src/renderer/src/rmmz/index.js
+++ b/src/renderer/src/rmmz/index.js
@@ -71,7 +71,6 @@ import {
   Sprite_Clickable,
   Sprite_Damage,
   Sprite_Destination,
-  Sprite_Enemy,
   Sprite_Gauge,
   Sprite_Name,
   Sprite_Picture,
@@ -176,7 +175,9 @@ import {
   Window_MenuCommand,
   Window_Options,
   Window_TitleCommand,
-  Window_GameEnd
+  Window_GameEnd,
+  // Sprites
+  Sprite_Enemy
 } from './edits/editsIndex'
 //=========================================
 // Import Custom


### PR DESCRIPTION
Fix the battleback scaling for widescreen resolution so the enemies / actors are on the ground.

Fix sideview actor placement.
Fix enemy placement.

Fix a bug when switching resolutions that you might end up with black bars on the top or sides. Now they won't end out of sync.

Changed the resolutions so they are closer together in sizes, left the ultra wide alone because trying to go to the next smallest looks odd.

Fixed Scene_Base.prototype.adjustBoxSize to use the ConfigManager for the UI area width/height.